### PR TITLE
Update the "modbus.vcproj" Visual Studio project file to solve an ERRNO problem in the WIN32 platform

### DIFF
--- a/src/win32/modbus.vcproj
+++ b/src/win32/modbus.vcproj
@@ -57,7 +57,7 @@
 				MinimalRebuild="false"
 				ExceptionHandling="0"
 				BasicRuntimeChecks="2"
-				RuntimeLibrary="1"
+				RuntimeLibrary="3"
 				FloatingPointModel="2"
 				UsePrecompiledHeader="0"
 				WarningLevel="3"


### PR DESCRIPTION
Under the WIN32 platform, a client application which uses the modbus.dll library file generated with the current project properties does not get the correct ERRNO value when the library signals an error.

This is due to the current "Runtime Library" project option which is set to "Multi-threaded Debug (/MTd)", causing the generated library to have its own copy of the C/C++ runtime library (CRT). As a consequence, CRT objects passed across the DLL boundary can be wrongly picked up by the client application since they use different copies of the CRT. See a discussion on that in the following link:

https://docs.microsoft.com/en-us/cpp/c-runtime-library/potential-errors-passing-crt-objects-across-dll-boundaries?view=vs-2017

In order to solve this problem, it suffices to set the above option to "Multi-threaded Debug DLL (/MDd)" which causes the client application and the library to share the same CRT. This option can be reached by opening the project properties window and navigating to C/C++ -> Code Generation -> Runtime Library.

The "modbus.vcproj" Visual Studio project file has been changed in order to correct this problem. The modbus.dll library generated with this project option change has been tested and now passes the correct ERRNO values to the client application.